### PR TITLE
fix: ensure calling points are always a list (fixes #4)

### DIFF
--- a/custom_components/nationalrailtimes/apidata.py
+++ b/custom_components/nationalrailtimes/apidata.py
@@ -102,7 +102,8 @@ class ApiData:
         """Get the stations the service stops at on route to the destination"""
         data = self.get_destination_data(crx)
         if data:
-            return data["subsequentCallingPoints"]["callingPointList"]["callingPoint"]
+            callingPoints = data["subsequentCallingPoints"]["callingPointList"]["callingPoint"]
+            return callingPoints if type(callingPoints) in [list, tuple] else [callingPoints] 
 
     def get_station_name(self):
         """Get the name of the station to watch for departures"""


### PR DESCRIPTION
## Description
Ensures that when there is only one calling point, it is still parsed as a list rather than as a single item.
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
This PR fixes or closes issue: fixes #4 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Locally on my HA
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.