### PR TITLE
Updated platform schema to support YAML configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ Simply go to the above link and choose [Register Here](http://realtime.nationalr
 ## Options
 
 | Name                 | Type    | Requirement  | Description                                                                                       | Default |
-| ---------------------| ------- | ------------ | --------------------------------------------------------------------------------------------------|---------|
+| ---------------------| ------- |--------------| --------------------------------------------------------------------------------------------------|---------|
 | api_key              | string  | **Required** | National Rail Darwin Feed API Key                                                                 | `none`  |
 | arrival              | string  | **Required** | 3 Letter CRX station code of your local station                                                   | `none`  |
 | destination          | string  | **Required** | 3 Letter CRX station code of your target destination station                                      | `none`  |
-| time_offset          | string  | **Required** | An offset in minutes against the current time to provide the station board for your local station | `none`  |
+| time_offset          | string  | **Optional** | An offset in minutes against the current time to provide the station board for your local station | `none`  |
 
 
 
@@ -85,6 +85,10 @@ Demo configuration:
 
 ```
 sensor:
+  - platform: nationalrailtimes
+    api_key: 1234abcd-1a2b3c-1a2b-9876-123abc456def
+    arrival: CHX
+    destination: ABW
   - platform: nationalrailtimes
     api_key: 1234abcd-1a2b3c-1a2b-9876-123abc456def
     arrival: ABW

--- a/custom_components/nationalrailtimes/sensor.py
+++ b/custom_components/nationalrailtimes/sensor.py
@@ -21,6 +21,8 @@ from .const import (
     CONF_TIME_WINDOW,
     DEFAULT_ICON,
     DEFAULT_NAME,
+    DEFAULT_TIME_OFFSET,
+    DEFAULT_TIME_WINDOW,
     DOMAIN,
     NATIONAL_RAIL_URL,
     SOAP_ACTION_URL,
@@ -38,8 +40,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_API_KEY): cv.string,
         vol.Required(CONF_ARRIVAL): cv.string,
-        vol.Required(CONF_TIME_OFFSET): cv.string,
-        vol.Required(CONF_TIME_WINDOW): cv.string,
+        vol.Optional(CONF_TIME_OFFSET, default=str(DEFAULT_TIME_OFFSET)): cv.string,
+        vol.Optional(CONF_TIME_WINDOW, default=str(DEFAULT_TIME_WINDOW)): cv.string,
+        vol.Required(CONF_DESTINATIONS): vol.All(cv.ensure_list, vol.Length(min=1), [cv.string]),
     }
 )
 
@@ -83,7 +86,7 @@ async def async_setup_platform(
 ) -> None:
     """Set up the sensor platform."""
     name = config.get(CONF_NAME)
-    station = config.get[CONF_ARRIVAL]
+    station = config.get(CONF_ARRIVAL)
     destinations = config.get(CONF_DESTINATIONS)
     api_key = config.get(CONF_API_KEY)
     time_offset = config.get(CONF_TIME_OFFSET)


### PR DESCRIPTION
## Description
Fixes configuring the sensor via YAML configuration.

## Related Issue
This PR fixes or closes issue: fixes #2

## Motivation and Context
Updated the platform schema to make `time_offset` and `time_window` optional as they have defaults, as well as added a schema entry for `destination`

## How Has This Been Tested

Tested this by installing my fork with HACS and declaring a YAML sensor.

Home Assistant version: 2023.11.2

## Types of changes
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

Whilst this adds a required platform field of `destination`, I wouldn't call it a breaking change considering it didn't work initially.

## Checklist
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change locally.